### PR TITLE
[feat] Remove TrustLocation

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -207,14 +207,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.16"
-  trust_location:
-    dependency: transitive
-    description:
-      name: trust_location
-      sha256: "2457f4bcd9ef8423fd12d8ae1701040ecef37a488e4a46bfa50bad26d8cf7d80"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.13"
   vector_math:
     dependency: transitive
     description:

--- a/lib/safe_device.dart
+++ b/lib/safe_device.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:trust_location/trust_location.dart';
 
 class SafeDevice {
   static const MethodChannel _channel = const MethodChannel('safe_device');
@@ -28,15 +27,6 @@ class SafeDevice {
         .toList();
   }
 
-  //Can this device mock location - no need to root!
-  static Future<bool> get canMockLocation async {
-    if (Platform.isAndroid) {
-      return await TrustLocation.isMockLocation;
-    } else {
-      return !await isRealDevice || await isJailBroken;
-    }
-  }
-
   // Checks whether device is real or emulator
   static Future<bool> get isRealDevice async {
     final bool isRealDevice = await _channel.invokeMethod('isRealDevice');
@@ -54,18 +44,14 @@ class SafeDevice {
   static Future<bool> get isSafeDevice async {
     final bool isJailBroken = await _channel.invokeMethod('isJailBroken');
     final bool isRealDevice = await _channel.invokeMethod('isRealDevice');
-    final bool canMockLocation = await SafeDevice.canMockLocation;
     if (Platform.isAndroid) {
       final bool isOnExternalStorage =
           await _channel.invokeMethod('isOnExternalStorage');
-      return isJailBroken ||
-              canMockLocation ||
-              !isRealDevice ||
-              isOnExternalStorage == true
+      return isJailBroken || !isRealDevice || isOnExternalStorage == true
           ? false
           : true;
     } else {
-      return isJailBroken || !isRealDevice || canMockLocation;
+      return isJailBroken || !isRealDevice;
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -152,14 +152,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.16"
-  trust_location:
-    dependency: "direct main"
-    description:
-      name: trust_location
-      sha256: "2457f4bcd9ef8423fd12d8ae1701040ecef37a488e4a46bfa50bad26d8cf7d80"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.13"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  trust_location: ^2.0.13 #for mock location (for now)
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Removing the library TrustLocation because this causes a delay when starting the app. The library call the location of user before Flutter start.